### PR TITLE
Add explicit fission Jacobians

### DIFF
--- a/include/kernels/SAAFFission.h
+++ b/include/kernels/SAAFFission.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "SAAFBaseKernel.h"
+
+// A class to compute the residual contribution from fission for the neutron-specific form of the
+// discrete ordinates radiation transport equation. This kernel assembles the full fission Jacobian.
+class SAAFFission : public SAAFBaseKernel
+{
+public:
+  static InputParameters validParams();
+
+  SAAFFission(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  Real computeScalarFlux(unsigned int g_prime);
+
+  // Total number of spectral energy groups.
+  const unsigned int _num_groups;
+
+  /*
+   * We assume that the vector of flux ordinates is stored in order of group
+   * first, direction second. An example for 2 energy groups (G = 2) and a
+   * quadrature set with 2 elements (N = 2) is given below:
+   *
+   * The flux ordinates are indexed as Psi_{g, n}:
+   * _group_flux_ordinates[0] = Psi_{1, 1}
+   * _group_flux_ordinates[0] = Psi_{1, 2}
+   * _group_flux_ordinates[0] = Psi_{2, 1}
+   * _group_flux_ordinates[0] = Psi_{2, 2}
+   */
+  std::map<unsigned int, std::pair<unsigned int, unsigned int>> _jvar_map;
+  std::vector<const VariableValue *> _group_flux_ordinates;
+
+  // The neutron production cross-sections.
+  const ADMaterialProperty<std::vector<Real>> & _nu_sigma_f_g;
+  // The fission production spectra.
+  const ADMaterialProperty<std::vector<Real>> & _chi_g;
+}; // class SAAFFission

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -122,9 +122,11 @@ TransportAction::validParams()
       "init_from_file", false, "If the simulation should be initialized from a file or not.");
   params.addParam<bool>(
       "use_scattering_jacobians", false, "Whether or not to use hand-coded scattering Jacobians.");
+  params.addParam<bool>(
+      "use_fission_jacobians", false, "Whether or not to use hand-coded fission Jacobians.");
 
-  params.addParamNamesToGroup("eigen max_anisotropy block use_scattering_jacobians init_from_file",
-                              "Simulation");
+  params.addParamNamesToGroup("eigen max_anisotropy block use_scattering_jacobians use_fission_jacobians "
+                              "init_from_file", "Simulation");
 
   //----------------------------------------------------------------------------
   // Quadrature parameters.
@@ -1855,8 +1857,50 @@ TransportAction::addSAAFKernels(const std::string & var_name, unsigned int g, un
   // neutron field.
   if (!getParam<bool>("debug_disable_fission") && _particle == NuclearData::Particletype::Neutron)
   {
-    // Add SAAFMomentFission.
+    // Add SAAFFission.
+    if (getParam<bool>("use_fission_jacobians"))
     {
+      auto params = _factory.getValidParams("SAAFFission");
+      params.set<NonlinearVariableName>("variable") = var_name;
+      // Set the name of the TransportAction so it can fetch the appropriate material
+      // properties.
+      params.set<std::string>("transport_system") = name();
+      // Group index and the number of groups are required to fetch the
+      // scattering cross-section moments.
+      params.set<unsigned int>("group_index") = g;
+      params.set<unsigned int>("num_groups") = _num_groups;
+      // Ordinate index is required to fetch the particle direction.
+      params.set<unsigned int>("ordinate_index") = n;
+
+      // Apply the parameters for the quadrature rule.
+      applyQuadratureParameters(params);
+
+      // Copy all of the group flux ordinate names into the variable
+      // parameter.
+      auto & ordinate_names = params.set<std::vector<VariableName>>("group_flux_ordinates");
+      for (unsigned int g_prime = 0; g_prime < _num_groups; ++g_prime)
+      {
+        std::copy(_group_angular_fluxes[g_prime].begin(),
+                  _group_angular_fluxes[g_prime].end(),
+                  std::back_inserter(ordinate_names));
+      }
+
+      if (isParamValid("block"))
+      {
+        params.set<std::vector<SubdomainName>>("block") =
+            getParam<std::vector<SubdomainName>>("block");
+      }
+
+      // For eigenvalues.
+      if (_is_eigen)
+        params.set<std::vector<TagName>>("extra_vector_tags").emplace_back("eigen");
+
+      _problem->addKernel("SAAFFission", "SAAFFission_" + var_name, params);
+      debugOutput("      - Adding kernel SAAFFission for the variable " + var_name + ".");
+    } // SAAFFission
+    else
+    {
+      // Add SAAFMomentFission.
       auto params = _factory.getValidParams("SAAFMomentFission");
       params.set<NonlinearVariableName>("variable") = var_name;
       // Set the name of the TransportAction so it can fetch the appropriate material
@@ -1897,11 +1941,8 @@ TransportAction::addSAAFKernels(const std::string & var_name, unsigned int g, un
   {
     // Debug option to disable the source iteration solver.
     if (!getParam<bool>("debug_disable_source_iteration"))
-    {
-      // Compute the scattering evaluation with source iteration.
       mooseError("Scattering iteration is not supported and is a work in "
                  "progress.");
-    }
     else
     {
       if (getParam<bool>("use_scattering_jacobians"))

--- a/src/kernels/SAAFFission.C
+++ b/src/kernels/SAAFFission.C
@@ -1,0 +1,111 @@
+#include "SAAFFission.h"
+
+registerMooseObject("GnatApp", SAAFFission);
+
+InputParameters
+SAAFFission::validParams()
+{
+  auto params = SAAFBaseKernel::validParams();
+  params.addClassDescription(
+    "Computes the fission source term for the SAAF discrete ordinates radiation transport "
+    "equation (specialized for neutrons). The weak form is given by: $-(\\psi_{j} + "
+    "\\tau_{g}\\vec{\\nabla}\\psi_{j}\\cdot\\hat{\\Omega}, \\frac{\\chi_{g}}{4\\pi}\\sum_{g' = "
+    "1}^{G}\\nu\\Sigma_{f,g}\\Phi_{g',0,0})$. The group scalar fluxes are computed by this kernel. "
+    "This kernel should not be exposed to the user, instead being enabled through a "
+    "transport action.");
+  params.addRequiredCoupledVar("group_flux_ordinates",
+                               "The angular flux ordinates for all groups.");
+  params.addRequiredRangeCheckedParam<unsigned int>("num_groups",
+                                                    "num_groups >= 1",
+                                                    "The number of spectral "
+                                                    "energy groups.");
+  return params;
+}
+
+SAAFFission::SAAFFission(const InputParameters & parameters)
+  : SAAFBaseKernel(parameters),
+    _num_groups(getParam<unsigned int>("num_groups")),
+    _nu_sigma_f_g(getADMaterialProperty<std::vector<Real>>(
+        getParam<std::string>("transport_system") + "production_xs_g")),
+    _chi_g(getADMaterialProperty<std::vector<Real>>(getParam<std::string>("transport_system") +
+                                                    "fission_spectra_g"))
+{
+  if (_group_index >= _num_groups)
+  mooseError("The group index exceeds the number of energy groups.");
+
+  if (_ordinate_index >= _aq.totalOrder())
+    mooseError("The ordinates index exceeds the number of quadrature points.");
+
+  const unsigned int num_coupled = coupledComponents("group_flux_ordinates");
+  if (num_coupled != _aq.totalOrder() * _num_groups)
+    mooseError("Mismatch between the angular flux ordinates and quadrature set.");
+
+  // Fetch the flux ordinates and their derivatives.
+  _group_flux_ordinates.reserve(num_coupled);
+  for (unsigned int i = 0; i < num_coupled; ++i)
+  {
+    unsigned int g = i / _aq.totalOrder();
+    unsigned int n = i - g * _aq.totalOrder();
+    _jvar_map.emplace(coupled("group_flux_ordinates", i), std::make_pair(g, n));
+    _group_flux_ordinates.emplace_back(&coupledValue("group_flux_ordinates", i));
+  }
+}
+
+Real
+SAAFFission::computeScalarFlux(unsigned int g_prime)
+{
+  Real moment = 0.0;
+  for (unsigned int n = 0; n < _aq.totalOrder(); ++n)
+    moment += (*_group_flux_ordinates[g_prime * _aq.totalOrder() + n])[_qp] * _aq.weight(n);
+
+  return moment;
+}
+
+Real
+SAAFFission::computeQpResidual()
+{
+  // Quit early if no fission cross-sections or fission spectra are provided.
+  if (_nu_sigma_f_g[_qp].size() == 0u || _chi_g[_qp].size() == 0u)
+    return 0.0;
+
+  Real res = 0.0;
+  for (unsigned int g_prime = 0u; g_prime < _num_groups; ++g_prime)
+    res += MetaPhysicL::raw_value(_nu_sigma_f_g[_qp][g_prime]) * computeScalarFlux(g_prime);
+
+  res *= MetaPhysicL::raw_value(_chi_g[_qp][_group_index]) / (4.0 * libMesh::pi) * _symmetry_factor;
+  return -1.0 * res * computeQpTests();
+}
+
+Real
+SAAFFission::computeQpJacobian()
+{
+  // Quit early if no fission cross-sections or fission spectra are provided.
+  if (_nu_sigma_f_g[_qp].size() == 0u || _chi_g[_qp].size() == 0u)
+    return 0.0;
+
+  Real jac = MetaPhysicL::raw_value(_chi_g[_qp][_group_index]) / (4.0 * libMesh::pi) *
+             _symmetry_factor * MetaPhysicL::raw_value(_nu_sigma_f_g[_qp][_group_index]) *
+             _aq.weight(_ordinate_index) * _phi[_j][_qp];
+
+  return -1.0 * jac * computeQpTests();
+}
+
+// TODO: Non-linear temperature and density need to be accounted for in the off-diagonal Jacobian.
+Real
+SAAFFission::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  // Quit early if no fission cross-sections or fission spectra are provided.
+  if (_nu_sigma_f_g[_qp].size() == 0u || _chi_g[_qp].size() == 0u)
+    return 0.0;
+
+  // Quit early if this would result in us hitting the on-diagonal Jacobian.
+  auto [g_prime, n_prime] = _jvar_map[jvar];
+  if (g_prime == _group_index && n_prime == _ordinate_index)
+    return 0.0;
+
+  Real jac = MetaPhysicL::raw_value(_chi_g[_qp][_group_index]) / (4.0 * libMesh::pi) *
+            _symmetry_factor * MetaPhysicL::raw_value(_nu_sigma_f_g[_qp][g_prime]) *
+            _aq.weight(n_prime) * _phi[_j][_qp];
+
+  return -1.0 * computeQpTests() * jac;
+}


### PR DESCRIPTION
Previously, the fission term in Gnat did not assemble the off-diagonal Jacobian entries to save on memory. This results in extremely slow convergence for criticality problems with large dominance ratios (e.g. CANDU style reactors like ZED-II) . 

This PR adds an option to the `TransportAction` similar to `use_scattering_jacobians` called `use_fission_jacobians` (defaulting to `false` to save memory), which allows the use of hand-coded fission Jacobians. This speeds up convergence dramatically in problems with fission, at the cost of added compute (computing scalar flux integrals of the flux and assembling off-diagonal Jacobian contributions) and memory (computing and storing the full Jacobian matrix).