### PR TITLE
Add option to clamp scattering ratios

### DIFF
--- a/include/actions/CardinalTransportMaterialAction.h
+++ b/include/actions/CardinalTransportMaterialAction.h
@@ -26,6 +26,11 @@ protected:
 
   const MultiAppName _xs_multi_app;
 
+  // Whether or not the scattering ratio should be clamped to a maximum value.
+  const bool _clamp_scatter_ratio;
+  // The value of the scattering ratio to clamp to. Should be less then 1.0.
+  const Real _scattering_ratio_clamp_factor;
+
   std::string _parent_transport_system;
   unsigned int _num_groups;
   MooseEnum _particle;

--- a/include/materials/PropsFromVarTransportMaterial.h
+++ b/include/materials/PropsFromVarTransportMaterial.h
@@ -12,6 +12,11 @@ public:
 protected:
   virtual void computeQpProperties() override;
 
+  // Whether or not the scattering ratio should be clamped to a maximum value.
+  const bool _clamp_scatter_ratio;
+  // The value of the scattering ratio to clamp to. Should be less then 1.0.
+  const Real _scattering_ratio_clamp_factor;
+
   // Total cross section variables for each group.
   std::vector<const VariableValue *> _sigma_t_g;
 

--- a/src/actions/CardinalTransportMaterialAction.C
+++ b/src/actions/CardinalTransportMaterialAction.C
@@ -42,6 +42,17 @@ CardinalTransportMaterialAction::validParams()
       false,
       "Whether or not per-group fission heating (kappa-fission) values should be generated.");
 
+  // Whether the scattering ratio should be clamped, and to what value.
+  params.addParam<bool>(
+    "clamp_scatter_ratio",
+    false,
+    "Whether or not the scattering ratio should be clamped to a maximum value to ensure convergence.");
+  params.addRangeCheckedParam<Real>(
+    "max_scatter_Ratio",
+    0.9999,
+    "0.0 < max_scatter_Ratio <= 1.0",
+    "The maximum value of the scattering ratio.");
+
   return params;
 }
 
@@ -49,6 +60,8 @@ CardinalTransportMaterialAction::CardinalTransportMaterialAction(const InputPara
   : GnatBaseAction(parameters),
     _xs_source(getParam<MooseEnum>("xs_source")),
     _xs_multi_app(isParamValid("from_multi_app") ? getParam<MultiAppName>("from_multi_app") : ""),
+    _clamp_scatter_ratio(getParam<bool>("clamp_scatter_ratio")),
+    _scattering_ratio_clamp_factor(getParam<Real>("max_scatter_Ratio")),
     _parent_transport_system(getParam<std::string>("transport_system")),
     _particle(MooseEnum("neutron photon", "neutron")),
     _scheme(MooseEnum("saaf_cfem diffusion_cfem flux_moment_transfer")),
@@ -239,6 +252,10 @@ CardinalTransportMaterialAction::addMaterials()
   params.set<bool>("has_fission") = _particle == "neutron" && !_disable_fission;
   params.set<std::string>("transport_system") = _parent_transport_system;
   params.set<bool>("add_heating") = _add_kappa_fission;
+
+  // For clamping the scattering ratios if requested.
+  params.set<bool>("clamp_scatter_ratio") = _clamp_scatter_ratio;
+  params.set<Real>("max_scatter_Ratio") = _scattering_ratio_clamp_factor;
 
   for (const auto & n : _total_var_names)
     params.set<std::vector<VariableName>>("total_xs").emplace_back(n);

--- a/src/actions/CardinalTransportMaterialAction.C
+++ b/src/actions/CardinalTransportMaterialAction.C
@@ -246,6 +246,7 @@ CardinalTransportMaterialAction::addMaterials()
   auto params = _factory.getValidParams("PropsFromVarTransportMaterial");
 
   params.set<unsigned int>("num_groups") = _num_groups;
+  params.set<unsigned int>("anisotropy") = _anisotropy;
   params.set<MooseEnum>("particle_type") = _particle;
   params.set<bool>("is_saaf") = _scheme == "saaf_cfem";
   params.set<bool>("is_diffusion") = _scheme == "diffusion_cfem";

--- a/src/materials/PropsFromVarTransportMaterial.C
+++ b/src/materials/PropsFromVarTransportMaterial.C
@@ -21,11 +21,24 @@ PropsFromVarTransportMaterial::validParams()
   params.addCoupledVar("absorption_xs", "The group-wise absorption cross section.");
   params.addCoupledVar("diffusion", "The group-wise particle diffusion coefficient.");
 
+  // Whether the scattering ratio should be clamped, and to what value.
+  params.addParam<bool>(
+    "clamp_scatter_ratio",
+    false,
+    "Whether or not the scattering ratio should be clamped to a maximum value to ensure convergence.");
+  params.addRangeCheckedParam<Real>(
+    "max_scatter_Ratio",
+    0.99,
+    "0.0 < max_scatter_Ratio <= 1.0",
+    "The maximum value of the scattering ratio.");
+
   return params;
 }
 
 PropsFromVarTransportMaterial::PropsFromVarTransportMaterial(const InputParameters & parameters)
   : EmptyTransportMaterial(parameters),
+    _clamp_scatter_ratio(getParam<bool>("clamp_scatter_ratio")),
+    _scattering_ratio_clamp_factor(getParam<Real>("max_scatter_Ratio")),
     _anisotropy(getParam<unsigned int>("anisotropy")),
     _max_moments((_anisotropy + 1u) * _num_groups * _num_groups)
 {
@@ -172,6 +185,16 @@ PropsFromVarTransportMaterial::computeQpProperties()
   _mat_sigma_s_g_prime_g_l[_qp].resize(_max_moments, 0.0);
   for (unsigned int i = 0u; i < _max_moments; ++i)
     _mat_sigma_s_g_prime_g_l[_qp][i] = (*(_sigma_s_g_prime_g_l[i]))[_qp];
+
+  if (_clamp_scatter_ratio && _anisotropy == 0u && _max_moments > 0u)
+  {
+    for (unsigned int g = 0; g < _num_groups; ++g)
+    {
+      const Real sr_g = (*(_sigma_s_g_prime_g_l[g * _num_groups + g]))[_qp] / (*(_sigma_t_g[g]))[_qp];
+      if (sr_g >= _scattering_ratio_clamp_factor)
+        _mat_sigma_s_g_prime_g_l[_qp][g * _num_groups + g] = _scattering_ratio_clamp_factor * (*(_sigma_t_g[g]))[_qp];
+    }
+  }
 
   // Fission production cross-sections and spectra.
   if (_has_fission)


### PR DESCRIPTION
This PR adds an option to the `PropsFromVarTransportMaterial` and `CardinalTransportMaterialAction` to clamp the maximum scattering ratio to a user-specified value. This is non-physical, but is useful in preventing high variance scattering cross sections from destabilizing the convergence of a solve. It is disabled by default.