### PR TITLE
Add a level-symmetric quadrature set

### DIFF
--- a/include/materials/EmptyTransportMaterial.h
+++ b/include/materials/EmptyTransportMaterial.h
@@ -56,4 +56,9 @@ protected:
   ADMaterialProperty<std::vector<Real>> * _mat_saaf_tau;
   Real _saaf_eta;
   Real _saaf_c;
+  const enum class HType
+  {
+    HMax = 0,
+    HMin = 1
+  } _h_type;
 }; // class EmptyTransportMaterial

--- a/include/userobjects/AQProvider.h
+++ b/include/userobjects/AQProvider.h
@@ -26,12 +26,6 @@ public:
   const std::vector<RealVectorValue> & getDirections() const { return _aq->getDirections(); }
   const std::vector<Real> & getWeights() const { return _aq->getWeights(); }
 
-  const Real & getPolarRoot(unsigned int n) const { return _aq->getPolarRoot(n); }
-  const Real & getAzimuthalAngularRoot(unsigned int n) const
-  {
-    return _aq->getAzimuthalAngularRoot(n);
-  }
-
   MajorAxis getAxis() const { return _aq->getAxis(); }
   ProblemType getProblemType() const { return _aq->getProblemType(); }
 

--- a/include/userobjects/AQProvider.h
+++ b/include/userobjects/AQProvider.h
@@ -32,8 +32,9 @@ public:
 protected:
   enum class AQType
   {
-    GaussChebyshev = 0u
-  } _aq_type;
+    GaussChebyshev = 0u,
+    LevelSymmetric = 1u
+  } _aq_type; //
 
   std::unique_ptr<AngularQuadrature> _aq;
 }; // class ThreadedGeneralUserObject

--- a/include/utils/AngularQuadrature.h
+++ b/include/utils/AngularQuadrature.h
@@ -20,9 +20,6 @@ public:
   virtual const std::vector<RealVectorValue> & getDirections() const = 0;
   virtual const std::vector<Real> & getWeights() const = 0;
 
-  virtual const Real & getPolarRoot(unsigned int n) const = 0;
-  virtual const Real & getAzimuthalAngularRoot(unsigned int n) const = 0;
-
   MajorAxis getAxis() const { return _axis; }
   ProblemType getProblemType() const { return _type; }
 

--- a/include/utils/GaussAngularQuadrature.h
+++ b/include/utils/GaussAngularQuadrature.h
@@ -27,9 +27,6 @@ public:
   const std::vector<RealVectorValue> & getDirections() const override;
   const std::vector<Real> & getWeights() const override;
 
-  const Real & getPolarRoot(unsigned int n) const override;
-  const Real & getAzimuthalAngularRoot(unsigned int n) const override;
-
   unsigned int legendreOrder() const { return _n_l; }
   LegendrePolynomial getPolarLegendre() const { return _polar_quadrature; }
 

--- a/include/utils/LSAngularQuadrature.h
+++ b/include/utils/LSAngularQuadrature.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <map>
+
+#include "AngularQuadrature.h"
+
+class LSAngularQuadrature : public AngularQuadrature
+{
+public:
+  LSAngularQuadrature(unsigned int q_order, MajorAxis axis = MajorAxis::X, ProblemType type = ProblemType::Cartesian3D);
+
+  unsigned int totalOrder() const override;
+  const RealVectorValue & direction(unsigned int n) const override;
+  const Real & weight(unsigned int n) const override;
+  const std::vector<RealVectorValue> & getDirections() const override;
+  const std::vector<Real> & getWeights() const override;
+
+private:
+  void addAllOctantPermutations(const Real & mu_1, const Real & mu_2, const Real & mu_3, const Real & w);
+
+  std::vector<RealVectorValue> _quadrature_set_omega;
+  std::vector<Real> _quadrature_set_weight;
+
+  static const std::map<unsigned int, std::vector<Real>> _ls_mus;
+  static const std::map<unsigned int, std::vector<Real>> _ls_weights;
+}; // class LSAngularQuadrature

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -19,6 +19,7 @@
 #include "libmesh/fe_type.h"
 
 #include "GaussAngularQuadrature.h"
+#include "LSAngularQuadrature.h"
 
 // All schemes.
 registerMooseAction("GnatApp", TransportAction, "add_variable");
@@ -130,6 +131,14 @@ TransportAction::validParams()
 
   //----------------------------------------------------------------------------
   // Quadrature parameters.
+  params.addParam<MooseEnum>("aq_type",
+                             MooseEnum("gauss_chebyshev level_symmetric", "gauss_chebyshev"),
+                             "The angular quadrature set to use. Defaults to Gauss-Chebyshev.");
+  params.addRangeCheckedParam<unsigned int>(
+      "ls_q_order",
+      4,
+      "1 < ls_q_order < 19",
+      "Order of the level-symmetric quadrature rule. Only required if 'aq_type' is 'level_symmetric'.");
   params.addRangeCheckedParam<unsigned int>("n_polar",
                                             3,
                                             "n_polar > 0",
@@ -151,7 +160,7 @@ TransportAction::validParams()
                              "axis with minimal heterogeneity. Default is the "
                              "x-axis. This parameter is only applied in 3D "
                              "cartesian problems.");
-  params.addParamNamesToGroup("n_polar n_azimuthal major_axis", "Quadrature");
+  params.addParamNamesToGroup("aq_type ls_q_order n_polar n_azimuthal major_axis", "Quadrature");
 
   //----------------------------------------------------------------------------
   // Source-driven problem parameters.
@@ -656,29 +665,51 @@ TransportAction::actCommon()
           break;
       }
 
-      switch (_p_type)
+      if (getParam<MooseEnum>("aq_type") == "level_symmetric")
       {
-        case ProblemType::Cartesian1D:
-          _num_flux_ordinates = 2u * _n_l;
-          break;
+        switch (_p_type)
+        {
+          case ProblemType::Cartesian1D:
+            mooseError("Level-symmetric quadratures do not support 1D calculations!");
+            break;
 
-        case ProblemType::Cartesian2D:
-          _num_flux_ordinates = 4u * _n_l * _n_c;
-          break;
+          case ProblemType::Cartesian2D:
+            _num_flux_ordinates = getParam<unsigned int>("ls_q_order") * (getParam<unsigned int>("ls_q_order") + 2) / 2;
+            break;
 
-        case ProblemType::Cartesian3D:
-          _num_flux_ordinates = 8u * _n_l * _n_c;
-          break;
+          case ProblemType::Cartesian3D:
+            _num_flux_ordinates = getParam<unsigned int>("ls_q_order") * (getParam<unsigned int>("ls_q_order") + 2);
+            break;
 
-        default:
-          mooseError("Unknown mesh dimensionality.");
-          break;
+          default:
+            mooseError("Unknown mesh dimensionality.");
+            break;
+        }
+      }
+      else
+      {
+        switch (_p_type)
+        {
+          case ProblemType::Cartesian1D:
+            _num_flux_ordinates = 2u * _n_l;
+            break;
+
+          case ProblemType::Cartesian2D:
+            _num_flux_ordinates = 4u * _n_l * _n_c;
+            break;
+
+          case ProblemType::Cartesian3D:
+            _num_flux_ordinates = 8u * _n_l * _n_c;
+            break;
+
+          default:
+            mooseError("Unknown mesh dimensionality.");
+            break;
+        }
       }
 
       std::string set_info(
           std::string("    - Angular quadrature set information:\n") +
-          std::string("      - Polar points per quadrant: ") + Moose::stringify(_n_l) +
-          std::string("\n      - Azimuthal points per quadrant: ") + Moose::stringify(_n_c) +
           std::string("\n      - Total number of flux ordinates: ") +
           Moose::stringify(_num_flux_ordinates));
       debugOutput(set_info);
@@ -1349,6 +1380,8 @@ TransportAction::addSNUserObjects()
     params.set<MooseEnum>("major_axis") = getParam<MooseEnum>("major_axis");
 
     // Assign quadrature rules.
+    params.set<MooseEnum>("aq_type") = getParam<MooseEnum>("aq_type");
+    params.set<unsigned int>("ls_q_order") = getParam<unsigned int>("ls_q_order");
     params.set<unsigned int>("n_l") = 2u * _n_l;
     params.set<unsigned int>("n_c") = 2u * _n_c;
 
@@ -1462,8 +1495,21 @@ TransportAction::addSNBCs(const std::string & var_name, unsigned int g, unsigned
     face_fe->attach_quadrature_rule(q_face.get());
 
     // The angular quadrature set to calculate reflected directions.
-    const auto aq = GaussAngularQuadrature(
-        2u * _n_c, 2u * _n_l, getParam<MooseEnum>("major_axis").getEnum<MajorAxis>(), _p_type);
+    std::unique_ptr<AngularQuadrature> aq;
+    if (getParam<MooseEnum>("aq_type") == "level_symmetric")
+    {
+      aq.reset(
+        new LSAngularQuadrature(getParam<unsigned int>("ls_q_order"),
+                                getParam<MooseEnum>("major_axis").getEnum<MajorAxis>(),
+                                _p_type));
+    }
+    else
+    {
+      aq.reset(
+        new GaussAngularQuadrature(2u * _n_c, 2u * _n_l,
+                                   getParam<MooseEnum>("major_axis").getEnum<MajorAxis>(),
+                                   _p_type));
+    }
 
     const auto & bnd_ids = _mesh->getBoundaryIDs(_reflective_side_sets);
 
@@ -1503,7 +1549,7 @@ TransportAction::addSNBCs(const std::string & var_name, unsigned int g, unsigned
                      Moose::stringify(static_cast<Point>(norm)));
 
       // Find the reflected directions.
-      auto curr_dir = aq.direction(n);
+      auto curr_dir = aq->direction(n);
       RealVectorValue refl_dir(0.0, 0.0, 0.0);
 
       std::vector<int> reflected_direction_indices;
@@ -1511,10 +1557,10 @@ TransportAction::addSNBCs(const std::string & var_name, unsigned int g, unsigned
 
       for (unsigned int norm_ind = 0u; norm_ind < unique_bnd_normals[i].size(); ++norm_ind)
       {
-        for (unsigned int n_prime = 0u; n_prime < aq.totalOrder(); ++n_prime)
+        for (unsigned int n_prime = 0u; n_prime < aq->totalOrder(); ++n_prime)
         {
-          refl_dir = aq.direction(n_prime) -
-                     (2.0 * aq.direction(n_prime) * unique_bnd_normals[i][norm_ind]) *
+          refl_dir = aq->direction(n_prime) -
+                     (2.0 * aq->direction(n_prime) * unique_bnd_normals[i][norm_ind]) *
                          unique_bnd_normals[i][norm_ind];
 
           if (vecEquals(curr_dir, refl_dir))

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -2380,7 +2380,7 @@ TransportAction::addDiffusionKernels(const std::string & var_name, unsigned int 
     params.set<unsigned int>("group_index") = g;
     params.set<unsigned int>("num_groups") = _num_groups;
 
-    // Copy all of the group flux ordinate names into the variable
+    // Copy all of the group scalar flux names into the variable
     // parameter.
     auto & scalar_flux_names = params.set<std::vector<VariableName>>("group_scalar_fluxes");
     for (unsigned int g_prime = 0; g_prime < _num_groups; ++g_prime)

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -424,6 +424,27 @@ TransportAction::TransportAction(const InputParameters & params)
     _source_scale_factor(0.0),
     _var_init(false)
 {
+  if (_volumetric_source_blocks.size() != _volumetric_source_moments.size() ||
+      _volumetric_source_blocks.size() != _volumetric_source_anisotropy.size())
+    mooseError("'volumetric_source_blocks', 'volumetric_source_moments', and 'volumetric_source_anisotropies' must be the same size!");
+
+  if (_point_source_locations.size() != _point_source_moments.size() ||
+      _point_source_locations.size() != _point_source_anisotropy.size())
+    mooseError("'point_source_locations', 'point_source_moments', and 'point_source_anisotropies' must be the same size!");
+
+  if (_source_side_sets.size() != _boundary_source_moments.size() ||
+      _source_side_sets.size() != _boundary_source_anisotropy.size())
+    mooseError("'source_boundaries', 'boundary_source_moments', and 'boundary_source_anisotropy' must be the same size!");
+
+  if (_current_side_sets.size() != _boundary_currents.size() ||
+      _current_side_sets.size() != _boundary_current_anisotropy.size())
+    mooseError("'current_boundaries', 'boundary_currents', and 'boundary_current_anisotropy' must be the same size!");
+
+  if (_field_source_blocks.size() != _field_source_moments.size() ||
+      _field_source_blocks.size() != _field_source_anisotropy.size() ||
+      _field_source_blocks.size() != _field_source_scaling.size())
+    mooseError("'field_source_blocks', 'field_source_moments', 'field_source_anisotropies', and 'field_source_scaling' must be the same size!");
+
   if (getParam<bool>("scale_sources"))
   {
     // Find the maximum source moment.

--- a/src/materials/AbsorbingTransportMaterial.C
+++ b/src/materials/AbsorbingTransportMaterial.C
@@ -89,7 +89,7 @@ AbsorbingTransportMaterial::computeQpProperties()
   {
     (*_mat_saaf_tau)[_qp].resize(_num_groups, 0.0);
 
-    auto h = _current_elem->hmin();
+    const auto h = _h_type == HType::HMax ? _current_elem->hmax() : _current_elem->hmin();
     for (unsigned int g = 0; g < _num_groups; ++g)
     {
       if (_sigma_t_g[g] * _saaf_c * h >= _saaf_eta)

--- a/src/materials/ConstantTransportMaterial.C
+++ b/src/materials/ConstantTransportMaterial.C
@@ -157,7 +157,7 @@ ConstantTransportMaterial::computeQpProperties()
   {
     (*_mat_saaf_tau)[_qp].resize(_num_groups, 0.0);
 
-    auto h = _current_elem->hmin();
+    const auto h = _h_type == HType::HMax ? _current_elem->hmax() : _current_elem->hmin();
     for (unsigned int g = 0; g < _num_groups; ++g)
     {
       if (_sigma_t_g[g] * _saaf_c * h >= _saaf_eta)

--- a/src/materials/EmptyTransportMaterial.C
+++ b/src/materials/EmptyTransportMaterial.C
@@ -42,6 +42,9 @@ EmptyTransportMaterial::validParams()
                         "Stabilization parameter c for the SAAF-CFEM scheme. "
                         "eta = 0 and c = 1 is equivalent to the SAAF approach "
                         "with no void treatment. Use with caution.");
+  params.addParam<MooseEnum>("h_type",
+                             MooseEnum("h_max h_min", "h_max"),
+                             "The element length to use for stabilization.");
 
   return params;
 }
@@ -89,7 +92,8 @@ EmptyTransportMaterial::EmptyTransportMaterial(const InputParameters & parameter
                                  getParam<std::string>("transport_system") + "saaf_tau")
                            : nullptr),
     _saaf_eta(getParam<Real>("saaf_eta")),
-    _saaf_c(getParam<Real>("saaf_c"))
+    _saaf_c(getParam<Real>("saaf_c")),
+    _h_type(getParam<MooseEnum>("h_type").getEnum<HType>())
 {
   if (_num_groups == 0u)
     mooseError("The provided number of energy groups is zero.");

--- a/src/materials/FileTransportMaterial.C
+++ b/src/materials/FileTransportMaterial.C
@@ -312,7 +312,7 @@ FileTransportMaterial::computeQpProperties()
   {
     (*_mat_saaf_tau)[_qp].resize(_num_groups, 0.0);
 
-    auto h = _current_elem->hmin();
+    const auto h = _h_type == HType::HMax ? _current_elem->hmax() : _current_elem->hmin();
     for (unsigned int g = 0; g < _num_groups; ++g)
     {
       if (_sigma_t_g[g] * _saaf_c * h >= _saaf_eta)

--- a/src/materials/PropsFromVarTransportMaterial.C
+++ b/src/materials/PropsFromVarTransportMaterial.C
@@ -145,7 +145,7 @@ PropsFromVarTransportMaterial::computeQpProperties()
   {
     (*_mat_saaf_tau)[_qp].resize(_num_groups, 0.0);
 
-    auto h = _current_elem->hmin();
+    const auto h = _h_type == HType::HMax ? _current_elem->hmax() : _current_elem->hmin();
     for (unsigned int g = 0; g < _num_groups; ++g)
     {
       if ((*(_sigma_t_g[g]))[_qp] * _saaf_c * h >= _saaf_eta)

--- a/src/materials/VoidTransportMaterial.C
+++ b/src/materials/VoidTransportMaterial.C
@@ -75,7 +75,7 @@ VoidTransportMaterial::computeQpProperties()
   {
     (*_mat_saaf_tau)[_qp].resize(_num_groups, 0.0);
 
-    auto h = _current_elem->hmin();
+    const auto h = _h_type == HType::HMax ? _current_elem->hmax() : _current_elem->hmin();
     for (unsigned int g = 0; g < _num_groups; ++g)
       (*_mat_saaf_tau)[_qp][g] = h / _saaf_eta;
   }

--- a/src/userobjects/AQProvider.C
+++ b/src/userobjects/AQProvider.C
@@ -1,6 +1,7 @@
 #include "AQProvider.h"
 
 #include "GaussAngularQuadrature.h"
+#include "LSAngularQuadrature.h"
 
 registerMooseObject("GnatApp", AQProvider);
 
@@ -16,7 +17,7 @@ AQProvider::validParams()
                                      "Dimensionality and the coordinate system of the "
                                      "problem.");
   params.addParam<MooseEnum>("aq_type",
-                             MooseEnum("gauss_chebyshev", "gauss_chebyshev"),
+                             MooseEnum("gauss_chebyshev level_symmetric", "gauss_chebyshev"),
                              "The angular quadrature set to use. Defaults to Gauss-Chebyshev.");
   params.addRangeCheckedParam<unsigned int>(
       "n_l",
@@ -30,6 +31,11 @@ AQProvider::validParams()
       "n_c > 0",
       "Order of the azimuthal product quadrature. Only required for Gauss-Chebyshev angular "
       "quadratures.");
+  params.addRangeCheckedParam<unsigned int>(
+      "ls_q_order",
+      4,
+      "1 < ls_q_order < 19",
+      "Order of the level-symmetric quadrature rule. Only required if 'aq_type' is 'level_symmetric'.");
   params.addParam<MooseEnum>("major_axis",
                              MooseEnum("x y z", "x"),
                              "Major axis of the angular quadrature. Allows the "
@@ -55,6 +61,11 @@ AQProvider::AQProvider(const InputParameters & parameters)
                                      getParam<MooseEnum>("major_axis").getEnum<MajorAxis>(),
                                      getParam<MooseEnum>("dimensionality").getEnum<ProblemType>()));
       break;
+    case AQType::LevelSymmetric:
+      _aq.reset(
+          new LSAngularQuadrature(getParam<unsigned int>("ls_q_order"),
+                                  getParam<MooseEnum>("major_axis").getEnum<MajorAxis>(),
+                                  getParam<MooseEnum>("dimensionality").getEnum<ProblemType>()));
     default:
       break;
   }

--- a/src/utils/GaussAngularQuadrature.C
+++ b/src/utils/GaussAngularQuadrature.C
@@ -46,36 +46,29 @@ GaussAngularQuadrature::totalOrder() const
 {
   return _quadrature_set_omega.size();
 }
+
 const RealVectorValue &
 GaussAngularQuadrature::direction(unsigned int n) const
 {
   return _quadrature_set_omega[n];
 }
+
 const Real &
 GaussAngularQuadrature::weight(unsigned int n) const
 {
   return _quadrature_set_weight[n];
 }
+
 const std::vector<RealVectorValue> &
 GaussAngularQuadrature::getDirections() const
 {
   return _quadrature_set_omega;
 }
+
 const std::vector<Real> &
 GaussAngularQuadrature::getWeights() const
 {
   return _quadrature_set_weight;
-}
-
-const Real &
-GaussAngularQuadrature::getPolarRoot(unsigned int n) const
-{
-  return _polar_quadrature.root(n / _n_l);
-}
-const Real &
-GaussAngularQuadrature::getAzimuthalAngularRoot(unsigned int n) const
-{
-  return _azimuthal_quadrature.angularRoot(n % _n_c);
 }
 
 void

--- a/src/utils/LSAngularQuadrature.C
+++ b/src/utils/LSAngularQuadrature.C
@@ -1,0 +1,244 @@
+#include "LSAngularQuadrature.h"
+
+LSAngularQuadrature::LSAngularQuadrature(unsigned int q_order, MajorAxis axis, ProblemType type)
+  : AngularQuadrature(std::move(axis), std::move(type))
+{
+  if (type == ProblemType::Cartesian1D)
+    mooseError("Level-symmetric quadratures only support 2D / 3D problem.");
+
+  if (q_order >= 20)
+    mooseError("Level-symmetric quadratures only support up to order 18 at present.");
+
+  if (q_order % 2 == 1)
+    mooseError("Odd quadrature orders are not supported by level symmetric quadrature rules.");
+
+  const auto & mus = _ls_mus.at(q_order);
+  const auto & weights = _ls_weights.at(q_order);
+
+  // Build the quadrature set in 3D by uncompacting the LS quadrature rule.
+  // Adapted from the LS quadrature rule in Moltres:
+  // https://github.com/arfc/moltres/blob/devel/src/utils/MoltresUtils.C#L162
+  unsigned int w_idx = 0;
+  for (unsigned int i = 0; i < (q_order + 5) / 6; ++i)
+  {
+    for (unsigned int j = i; j < ((q_order / 2 - i) + 1) / 2; ++j)
+    {
+      unsigned int k = q_order / 2 - 1 - i - j;
+      // For each unique combination of x,y,z component magnitudes, permute through all possible
+      // permutations (including for positive and negative components).
+      addAllOctantPermutations(mus[i], mus[j], mus[k], weights[w_idx]);
+      if (i == j && i == k)
+      {
+        // No extra permutations. Do nothing
+      }
+      else if (i == j)
+      {
+        addAllOctantPermutations(mus[k], mus[i], mus[i], weights[w_idx]);
+        addAllOctantPermutations(mus[i], mus[k], mus[i], weights[w_idx]);
+      }
+      else if (j == k)
+      {
+        addAllOctantPermutations(mus[j], mus[i], mus[j], weights[w_idx]);
+        addAllOctantPermutations(mus[j], mus[j], mus[i], weights[w_idx]);
+      }
+      else
+      {
+        addAllOctantPermutations(mus[k], mus[i], mus[j], weights[w_idx]);
+        addAllOctantPermutations(mus[j], mus[k], mus[i], weights[w_idx]);
+        addAllOctantPermutations(mus[k], mus[j], mus[i], weights[w_idx]);
+        addAllOctantPermutations(mus[i], mus[k], mus[j], weights[w_idx]);
+        addAllOctantPermutations(mus[j], mus[i], mus[k], weights[w_idx]);
+      }
+      w_idx += 1;
+    }
+  }
+
+  if (q_order * (q_order + 2) != _quadrature_set_omega.size() && type == ProblemType::Cartesian3D)
+    mooseError("Quadrature does not meet the level symmetric quadrature identity!");
+  if (q_order * (q_order + 2) / 2u != _quadrature_set_omega.size() && type == ProblemType::Cartesian2D)
+    mooseError("Quadrature does not meet the level symmetric quadrature identity!");
+}
+
+void
+LSAngularQuadrature::addAllOctantPermutations(const Real & mu_1, const Real & mu_2, const Real & mu_3, const Real & w)
+{
+  _quadrature_set_omega.emplace_back( mu_1,  mu_2,  mu_3);
+  _quadrature_set_omega.emplace_back(-mu_1,  mu_2,  mu_3);
+  _quadrature_set_omega.emplace_back( mu_1, -mu_2,  mu_3);
+  _quadrature_set_omega.emplace_back(-mu_1, -mu_2,  mu_3);
+  if (_type == ProblemType::Cartesian3D)
+  {
+    _quadrature_set_omega.emplace_back( mu_1,  mu_2, -mu_3);
+    _quadrature_set_omega.emplace_back(-mu_1,  mu_2, -mu_3);
+    _quadrature_set_omega.emplace_back( mu_1, -mu_2, -mu_3);
+    _quadrature_set_omega.emplace_back(-mu_1, -mu_2, -mu_3);
+
+    for (unsigned int i = 0u; i < 4u; ++i)
+      _quadrature_set_weight.emplace_back(w);
+  }
+
+  for (unsigned int i = 0u; i < 4u; ++i)
+    _quadrature_set_weight.emplace_back(w);
+}
+
+unsigned int
+LSAngularQuadrature::totalOrder() const
+{
+  return _quadrature_set_omega.size();
+}
+
+const RealVectorValue &
+LSAngularQuadrature::direction(unsigned int n) const
+{
+  return _quadrature_set_omega[n];
+}
+
+const Real &
+LSAngularQuadrature::weight(unsigned int n) const
+{
+  return _quadrature_set_weight[n];
+}
+
+const std::vector<RealVectorValue> &
+LSAngularQuadrature::getDirections() const
+{
+  return _quadrature_set_omega;
+}
+
+const std::vector<Real> &
+LSAngularQuadrature::getWeights() const
+{
+  return _quadrature_set_weight;
+}
+
+// Adapted from the LS quadrature rule in Moltres:
+// https://github.com/arfc/moltres/blob/devel/src/utils/MoltresUtils.C#L11-L136
+const std::map<unsigned int, std::vector<Real>> LSAngularQuadrature::_ls_mus
+{
+  { 2u,
+    { 0.5773502691896257 }
+  },
+  { 4u,
+    { 0.3500211745815407,
+     0.8688903007222011 }
+  },
+  { 6u,
+    { 0.2666354015167047,
+      0.6815077265365469,
+      0.9261809355174891 }
+  },
+  { 8u,
+    { 0.2182178902359924,
+      0.5773502691896257,
+      0.7867957924694432,
+      0.9511897312113419 }
+  },
+  { 10u,
+    { 0.1893213264780105,
+      0.5088817555826189,
+      0.6943188875943843,
+      0.8397599622366847,
+      0.9634909811104685 }
+  },
+  { 12u,
+    { 0.1672324971414912,
+      0.4595505230549429,
+      0.6280180398523312,
+      0.7600175218505538,
+      0.8722652169264515,
+      0.9716308886607312 }
+  },
+  { 14u,
+    { 0.1519858614610319,
+      0.4221569823047970,
+      0.5773502691896257,
+      0.6988920867759013,
+      0.8022262552314120,
+      0.8936910988743567,
+      0.9766271529257704 }
+  },
+  { 16u,
+    { 0.1389756946126266,
+      0.3922930709799660,
+      0.5370972569141674,
+      0.6504253018068668,
+      0.7467480720272295,
+      0.8319929644667765,
+      0.9092809811978063,
+      0.9804955444130666 }
+  },
+  { 18u,
+    { 0.1293481120858299,
+      0.3680446084547432,
+      0.5041653831086007,
+      0.6106624544193616,
+      0.7011665515053579,
+      0.7812556768832803,
+      0.8538655235895108,
+      0.9207671975517081,
+      0.9831267119754519 }
+  }
+};
+
+const std::map<unsigned int, std::vector<Real>> LSAngularQuadrature::_ls_weights
+{
+  { 2u,
+    { 1.0 }
+  },
+  { 4u,
+    { 0.33333333333333333 }
+  },
+  { 6u,
+    { 0.17612613086338347,
+      0.15720720246994987 }
+  },
+  { 8u,
+    { 0.12098765432098764,
+      0.09074074074074068,
+      0.09259259259259299 }
+  },
+  { 10u,
+    { 0.08930314798435690,
+      0.07252915171236500,
+      0.04504376743641028,
+      0.05392811448783617 }
+  },
+  { 12u,
+    { 0.07077307572802660,
+      0.05587899520720631,
+      0.03734279426952707,
+      0.05025193141404591,
+      0.02586474723779406 }
+  },
+  { 14u,
+    { 0.05799704089700514,
+      0.04890079763678386,
+      0.02279353424122489,
+      0.03941320059498668,
+      0.03809908614408365,
+      0.02583940764180201,
+      0.00826957997290902 }
+  },
+  { 16u,
+    { 0.04899634978321998,
+      0.04132620269749813,
+      0.02031234525671927,
+      0.02654915237867853,
+      0.03787631708434387,
+      0.01355542870643232,
+      0.03259039327572704,
+      0.01038401511138594 }
+  },
+  { 18u,
+    { 0.04226679857587908,
+      0.03760984374258203,
+      0.01227772553689008,
+      0.03240535837316794,
+      0.00666131638823868,
+      0.03120767364508285,
+      0.01601092912564359,
+      0.02004736607851901,
+      0.00012094114211235,
+      0.01637415786841503 }
+  }
+};


### PR DESCRIPTION
This PR implements a level-symmetric angular quadrature set based on the implementation in Moltres. See https://github.com/arfc/moltres/blob/devel/src/utils/MoltresUtils.C for additional details.