### PR TITLE
Improve performance in scattering/fission residual evaluations

### DIFF
--- a/examples/1D_point_streaming_cgfem/test.i
+++ b/examples/1D_point_streaming_cgfem/test.i
@@ -25,6 +25,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_polar = 10
 
     vacuum_boundaries = 'left right'

--- a/examples/2D_C5G7_full/neutronics.i
+++ b/examples/2D_C5G7_full/neutronics.i
@@ -23,11 +23,15 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 
     reflective_boundaries = 'reflective'
     vacuum_boundaries = 'vacuum'
+
+    use_scattering_jacobians = true
+    use_fission_jacobians = true
   []
 []
 

--- a/examples/2D_C5G7_simplified/neutronics.i
+++ b/examples/2D_C5G7_simplified/neutronics.i
@@ -21,6 +21,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_ackroyd_riyait_1_cgfem/test.i
+++ b/examples/2D_ackroyd_riyait_1_cgfem/test.i
@@ -25,6 +25,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 10
     n_polar = 10
 

--- a/examples/2D_ackroyd_riyait_2_cgfem/test.i
+++ b/examples/2D_ackroyd_riyait_2_cgfem/test.i
@@ -27,6 +27,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 10
     n_polar = 10
 

--- a/examples/2D_air_uvc_cgfem/test.i
+++ b/examples/2D_air_uvc_cgfem/test.i
@@ -21,6 +21,7 @@
     order = FIRST
     family = LAGRANGE
 
+    q_type = 'gauss_chebyshev'
     n_azimuthal = 18
     n_polar = 18
 

--- a/examples/2D_containment_2_transient_fine_e/neutronics.i
+++ b/examples/2D_containment_2_transient_fine_e/neutronics.i
@@ -21,6 +21,7 @@
 
     is_conservative_transfer_src = true
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_containment_2_transient_fine_e/neutronics_combined.i
+++ b/examples/2D_containment_2_transient_fine_e/neutronics_combined.i
@@ -21,6 +21,7 @@
 
     is_conservative_transfer_src = true
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_containment_transient_fine_e/neutronics.i
+++ b/examples/2D_containment_transient_fine_e/neutronics.i
@@ -21,6 +21,7 @@
 
     is_conservative_transfer_src = true
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_multiapp/sub.i
+++ b/examples/2D_multiapp/sub.i
@@ -22,6 +22,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 2
     n_polar = 2
 

--- a/examples/2D_multisystem_cgfem/test.i
+++ b/examples/2D_multisystem_cgfem/test.i
@@ -26,6 +26,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 
@@ -48,6 +49,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 

--- a/examples/2D_rad_con/radiation_steady.i
+++ b/examples/2D_rad_con/radiation_steady.i
@@ -17,6 +17,8 @@
 
     num_groups = 1
     max_anisotropy = 0
+
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 7
     n_polar = 7
 

--- a/examples/2D_rad_con/radiation_transient.i
+++ b/examples/2D_rad_con/radiation_transient.i
@@ -17,6 +17,8 @@
 
     num_groups = 1
     max_anisotropy = 0
+
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 

--- a/examples/2D_scattering_2_group_cgfem/test.i
+++ b/examples/2D_scattering_2_group_cgfem/test.i
@@ -23,6 +23,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 2
     n_polar = 2
 

--- a/examples/2D_source_cgfem/test.i
+++ b/examples/2D_source_cgfem/test.i
@@ -4,13 +4,23 @@
 [Mesh]
   [domain]
     type = CartesianMeshGenerator
-    dim = 2
-    dx = '4 20 20'
-    dy = '4 20 20'
-    ix = '4 20 20'
-    iy = '4 20 20'
+    dim = 3
+    dx = '5 5 5'
+    dy = '5 5 5'
+    dz = '5 5 5'
+    ix = '5 5 5'
+    iy = '5 5 5'
+    iz = '5 5 5'
     subdomain_id = '
-      2 1 1
+      1 1 1
+      1 1 1
+      1 1 1
+
+      1 1 1
+      1 2 1
+      1 1 1
+
+      1 1 1
       1 1 1
       1 1 1'
   []
@@ -26,15 +36,15 @@
     order = FIRST
     family = LAGRANGE
 
-    n_azimuthal = 20
-    n_polar = 20
+    aq_type = level_symmetric
+    ls_q_order = 18
 
     volumetric_source_blocks = '2'
     volumetric_source_moments = '1e0'
     volumetric_source_anisotropies = '0'
     scale_sources = true
 
-    vacuum_boundaries = 'left right top bottom'
+    vacuum_boundaries = 'left right top bottom front back'
   []
 []
 

--- a/examples/2D_subcritical_1_group_cgfem/neutronics.i
+++ b/examples/2D_subcritical_1_group_cgfem/neutronics.i
@@ -18,6 +18,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 4
     n_polar = 4
 

--- a/examples/2D_subcritical_8_group_seg_cgfem/neutronics.i
+++ b/examples/2D_subcritical_8_group_seg_cgfem/neutronics.i
@@ -18,6 +18,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 4
     n_polar = 4
 

--- a/examples/2D_subcritical_reactor_1_group/neutronics_transport.i
+++ b/examples/2D_subcritical_reactor_1_group/neutronics_transport.i
@@ -18,6 +18,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_subcritical_reactor_1_group/neutronics_transport_eigen.i
+++ b/examples/2D_subcritical_reactor_1_group/neutronics_transport_eigen.i
@@ -20,10 +20,14 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 
     vacuum_boundaries = 'vacuum'
+
+    use_fission_jacobians    = true
+    use_scattering_jacobians = true
   []
 []
 

--- a/examples/2D_subcritical_reactor_4_groups/neutronics.i
+++ b/examples/2D_subcritical_reactor_4_groups/neutronics.i
@@ -21,6 +21,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 

--- a/examples/2D_subcritical_reactor_4_groups/neutronics_eigen.i
+++ b/examples/2D_subcritical_reactor_4_groups/neutronics_eigen.i
@@ -21,11 +21,14 @@
 
     constant_ic = '1.0'
 
-    n_azimuthal = 3
-    n_polar = 3
+    aq_type = level_symmetric
+    ls_q_order = 8
 
     vacuum_boundaries = 'vacuum'
     reflective_boundaries = 'reflective'
+
+    use_fission_jacobians    = true
+    use_scattering_jacobians = true
   []
 []
 

--- a/examples/2D_surface_current_cgfem/test.i
+++ b/examples/2D_surface_current_cgfem/test.i
@@ -23,6 +23,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/2D_watanabe_maynard_cfem/test.i
+++ b/examples/2D_watanabe_maynard_cfem/test.i
@@ -26,6 +26,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 7
     n_polar = 7
 

--- a/examples/2D_water_steady_cgfem/test.i
+++ b/examples/2D_water_steady_cgfem/test.i
@@ -19,15 +19,15 @@
 [TransportSystems]
   [Neutron]
     num_groups = 2
-    max_anisotropy = 1
+    max_anisotropy = 0
     scheme = saaf_cfem
     particle_type = neutron
 
     order = FIRST
     family = LAGRANGE
 
-    n_azimuthal = 5
-    n_polar = 5
+    aq_type = 'level_symmetric'
+    ls_q_order = 4
 
     vacuum_boundaries = 'left right top bottom'
 
@@ -35,6 +35,8 @@
     point_source_moments = '1e6 0.0'
     point_source_anisotropies = '0'
     scale_sources = true
+
+    use_scattering_jacobians = true
   []
 []
 

--- a/examples/3D_kobayashi/kobayashi_1.i
+++ b/examples/3D_kobayashi/kobayashi_1.i
@@ -34,6 +34,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_kobayashi/kobayashi_1_no_rt.i
+++ b/examples/3D_kobayashi/kobayashi_1_no_rt.i
@@ -34,6 +34,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_kobayashi/kobayashi_2.i
+++ b/examples/3D_kobayashi/kobayashi_2.i
@@ -28,6 +28,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_kobayashi/kobayashi_2_no_rt.i
+++ b/examples/3D_kobayashi/kobayashi_2_no_rt.i
@@ -28,6 +28,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_kobayashi/kobayashi_3.i
+++ b/examples/3D_kobayashi/kobayashi_3.i
@@ -42,6 +42,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_kobayashi/kobayashi_3_no_rt.i
+++ b/examples/3D_kobayashi/kobayashi_3_no_rt.i
@@ -42,6 +42,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/examples/3D_subcritical_assembly/neutronics_transport.i
+++ b/examples/3D_subcritical_assembly/neutronics_transport.i
@@ -25,6 +25,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 

--- a/examples/3D_subcritical_cardinal_xs/neutronics_transport.i
+++ b/examples/3D_subcritical_cardinal_xs/neutronics_transport.i
@@ -42,7 +42,8 @@
     family = LAGRANGE
     order = FIRST
 
-    # The number of angles to use for the SN approximation.
+    # The type of quadrature set and number of angles to use for the SN approximation.
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 3
     n_polar = 3
 

--- a/include/kernels/SAAFFission.h
+++ b/include/kernels/SAAFFission.h
@@ -15,25 +15,14 @@ protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
-
-  Real computeScalarFlux(unsigned int g_prime);
-
   // Total number of spectral energy groups.
   const unsigned int _num_groups;
 
-  /*
-   * We assume that the vector of flux ordinates is stored in order of group
-   * first, direction second. An example for 2 energy groups (G = 2) and a
-   * quadrature set with 2 elements (N = 2) is given below:
-   *
-   * The flux ordinates are indexed as Psi_{g, n}:
-   * _group_flux_ordinates[0] = Psi_{1, 1}
-   * _group_flux_ordinates[0] = Psi_{1, 2}
-   * _group_flux_ordinates[0] = Psi_{2, 1}
-   * _group_flux_ordinates[0] = Psi_{2, 2}
-   */
+  // A map between the coupleable variable ID and the ordinate / group index.
   std::map<unsigned int, std::pair<unsigned int, unsigned int>> _jvar_map;
-  std::vector<const VariableValue *> _group_flux_ordinates;
+
+  // The required scalar fluxes which we actually use for calculations.
+  std::vector<const VariableValue *> _group_scalar_fluxes;
 
   // The neutron production cross-sections.
   const ADMaterialProperty<std::vector<Real>> & _nu_sigma_f_g;

--- a/include/kernels/SAAFScattering.h
+++ b/include/kernels/SAAFScattering.h
@@ -14,25 +14,16 @@ protected:
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  Real computeFluxMoment(unsigned int g_prime, unsigned int degree, int order);
-
   const unsigned int _num_groups;     // G
   const unsigned int _max_anisotropy; // L
-  unsigned int _num_dir_sh;           // Number of spherical harmonics evaluations per direction.
+  // Total number of flux moments per particle energy group.
+  unsigned int _num_moments_per_group;
 
-  /*
-   * We assume that the vector of flux ordinates is stored in order of group
-   * first, direction second. An example for 2 energy groups (G = 2) and a
-   * quadrature set with 2 elements (N = 2) is given below:
-   *
-   * The flux ordinates are indexed as Psi_{g, n}:
-   * _group_flux_ordinates[0] = Psi_{1, 1}
-   * _group_flux_ordinates[0] = Psi_{1, 2}
-   * _group_flux_ordinates[0] = Psi_{2, 1}
-   * _group_flux_ordinates[0] = Psi_{2, 2}
-   */
+  // A map between the coupleable variable ID and the ordinate / group index.
   std::map<unsigned int, std::pair<unsigned int, unsigned int>> _jvar_map;
-  std::vector<const VariableValue *> _group_flux_ordinates;
+
+  // The flux moments.
+  std::vector<const VariableValue *> _group_flux_moments;
 
   /*
    * We assume that the vector of scattering cross-sections is stored in the

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -131,9 +131,9 @@ TransportAction::validParams()
 
   //----------------------------------------------------------------------------
   // Quadrature parameters.
-  params.addRequiredParam<MooseEnum>("aq_type",
-                                     MooseEnum("gauss_chebyshev level_symmetric"),
-                                     "The angular quadrature set to use.");
+  params.addParam<MooseEnum>("aq_type",
+                             MooseEnum("gauss_chebyshev level_symmetric"),
+                             "The angular quadrature set to use.");
   params.addRangeCheckedParam<unsigned int>(
       "ls_q_order",
       4,
@@ -424,6 +424,9 @@ TransportAction::TransportAction(const InputParameters & params)
     _source_scale_factor(0.0),
     _var_init(false)
 {
+  if (_transport_scheme == TransportScheme::SAAFCFEM && !isParamSetByUser("aq_type"))
+    paramError("aq_type", "When using the SAAF-SN scheme, you must specify an angular quadrature type!");
+
   if (_volumetric_source_blocks.size() != _volumetric_source_moments.size() ||
       _volumetric_source_blocks.size() != _volumetric_source_anisotropy.size())
     mooseError("'volumetric_source_blocks', 'volumetric_source_moments', and 'volumetric_source_anisotropies' must be the same size!");

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -1955,6 +1955,11 @@ TransportAction::addSAAFKernels(const std::string & var_name, unsigned int g, un
                   std::back_inserter(ordinate_names));
       }
 
+      // Copy all of the scalar flux names into the variable parameter.
+      auto & scalar_flux_names = params.set<std::vector<VariableName>>("group_scalar_fluxes");
+      for (unsigned int g_prime = 0; g_prime < _num_groups; ++g_prime)
+        scalar_flux_names.emplace_back(_group_flux_moments[g_prime][0u]);
+
       if (isParamValid("block"))
       {
         params.set<std::vector<SubdomainName>>("block") =

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -659,11 +659,6 @@ TransportAction::actCommon()
           _p_type = ProblemType::Cartesian3D;
           _num_group_moments = (_max_eval_anisotropy + 1u) * (_max_eval_anisotropy + 1u);
 
-          if (_max_eval_anisotropy > 0u)
-            mooseWarning(
-                "Anisotropic scattering is currently bugged in 3D and will occasionally "
-                "result in a DIVERGED_FNORM_NAN error during parallel residual evaluations.");
-
           for (unsigned int g = 0; g < _num_groups; ++g)
           {
             // Set up variable names for the group flux moments.
@@ -2050,6 +2045,16 @@ TransportAction::addSAAFKernels(const std::string & var_name, unsigned int g, un
             std::copy(_group_angular_fluxes[g_prime].begin(),
                       _group_angular_fluxes[g_prime].end(),
                       std::back_inserter(ordinate_names));
+          }
+
+          // Copy all of the group flux moment names into the variable
+          // parameter.
+          auto & moment_names = params.set<std::vector<VariableName>>("group_flux_moments");
+          for (unsigned int g_prime = 0; g_prime < _num_groups; ++g_prime)
+          {
+            std::copy(_group_flux_moments[g_prime].begin(),
+                      _group_flux_moments[g_prime].end(),
+                      std::back_inserter(moment_names));
           }
 
           if (isParamValid("block"))

--- a/src/actions/TransportAction.C
+++ b/src/actions/TransportAction.C
@@ -131,9 +131,9 @@ TransportAction::validParams()
 
   //----------------------------------------------------------------------------
   // Quadrature parameters.
-  params.addParam<MooseEnum>("aq_type",
-                             MooseEnum("gauss_chebyshev level_symmetric", "gauss_chebyshev"),
-                             "The angular quadrature set to use. Defaults to Gauss-Chebyshev.");
+  params.addRequiredParam<MooseEnum>("aq_type",
+                                     MooseEnum("gauss_chebyshev level_symmetric"),
+                                     "The angular quadrature set to use.");
   params.addRangeCheckedParam<unsigned int>(
       "ls_q_order",
       4,

--- a/src/kernels/SAAFFission.C
+++ b/src/kernels/SAAFFission.C
@@ -13,8 +13,14 @@ SAAFFission::validParams()
     "1}^{G}\\nu\\Sigma_{f,g}\\Phi_{g',0,0})$. The group scalar fluxes are computed by this kernel. "
     "This kernel should not be exposed to the user, instead being enabled through a "
     "transport action.");
-  params.addRequiredCoupledVar("group_flux_ordinates",
-                               "The angular flux ordinates for all groups.");
+  params.addRequiredCoupledVar(
+      "group_flux_ordinates",
+      "The angular flux ordinates for all groups. These variables are used to inform the coupleable "
+      "interface (to setup Jacobians), and aren't actually required for any calculations.");
+  params.addRequiredCoupledVar(
+      "group_scalar_fluxes",
+      "The scalar fluxes (zero'th moments of the angular fluxes) for all spectral energy groups. We use "
+      "these moments to compute the fission term");
   params.addRequiredRangeCheckedParam<unsigned int>("num_groups",
                                                     "num_groups >= 1",
                                                     "The number of spectral "
@@ -36,29 +42,25 @@ SAAFFission::SAAFFission(const InputParameters & parameters)
   if (_ordinate_index >= _aq.totalOrder())
     mooseError("The ordinates index exceeds the number of quadrature points.");
 
-  const unsigned int num_coupled = coupledComponents("group_flux_ordinates");
-  if (num_coupled != _aq.totalOrder() * _num_groups)
+  const unsigned int num_ord = coupledComponents("group_flux_ordinates");
+  if (num_ord != _aq.totalOrder() * _num_groups)
     mooseError("Mismatch between the angular flux ordinates and quadrature set.");
 
-  // Fetch the flux ordinates and their derivatives.
-  _group_flux_ordinates.reserve(num_coupled);
-  for (unsigned int i = 0; i < num_coupled; ++i)
+  // Fetch the flux ordinate derivatives.
+  for (unsigned int i = 0; i < num_ord; ++i)
   {
     unsigned int g = i / _aq.totalOrder();
     unsigned int n = i - g * _aq.totalOrder();
     _jvar_map.emplace(coupled("group_flux_ordinates", i), std::make_pair(g, n));
-    _group_flux_ordinates.emplace_back(&coupledValue("group_flux_ordinates", i));
   }
-}
 
-Real
-SAAFFission::computeScalarFlux(unsigned int g_prime)
-{
-  Real moment = 0.0;
-  for (unsigned int n = 0; n < _aq.totalOrder(); ++n)
-    moment += (*_group_flux_ordinates[g_prime * _aq.totalOrder() + n])[_qp] * _aq.weight(n);
+  const unsigned int num_scal = coupledComponents("group_scalar_fluxes");
+  if (num_scal != _num_groups)
+    mooseError("Mismatch between the number of scalar fluxes and the number of groups.");
 
-  return moment;
+  _group_scalar_fluxes.reserve(num_scal);
+  for (unsigned int i = 0u; i < num_scal; ++i)
+    _group_scalar_fluxes.emplace_back(&coupledValue("group_scalar_fluxes", i));
 }
 
 Real
@@ -70,7 +72,7 @@ SAAFFission::computeQpResidual()
 
   Real res = 0.0;
   for (unsigned int g_prime = 0u; g_prime < _num_groups; ++g_prime)
-    res += MetaPhysicL::raw_value(_nu_sigma_f_g[_qp][g_prime]) * computeScalarFlux(g_prime);
+    res += MetaPhysicL::raw_value(_nu_sigma_f_g[_qp][g_prime]) * (*_group_scalar_fluxes[g_prime])[_qp];
 
   res *= MetaPhysicL::raw_value(_chi_g[_qp][_group_index]) / (4.0 * libMesh::pi) * _symmetry_factor;
   return -1.0 * res * computeQpTests();

--- a/src/kernels/SAAFScattering.C
+++ b/src/kernels/SAAFScattering.C
@@ -23,6 +23,7 @@ SAAFScattering::validParams()
                              "enabled through a transport action.");
   params.addRequiredCoupledVar("group_flux_ordinates",
                                "The angular flux ordinates for all groups.");
+  params.addRequiredCoupledVar("group_flux_moments", "The angular flux moments for all groups.");
   params.addRequiredRangeCheckedParam<unsigned int>("num_groups",
                                                     "num_groups >= 1",
                                                     "The number of spectral "
@@ -44,42 +45,55 @@ SAAFScattering::SAAFScattering(const InputParameters & parameters)
     _anisotropy(getMaterialProperty<unsigned int>(getParam<std::string>("transport_system") +
                                                   "medium_anisotropy"))
 {
+  switch (_aq.getProblemType())
+  {
+    case ProblemType::Cartesian1D:
+      _num_moments_per_group = _max_anisotropy + 1u;
+      break;
+
+    case ProblemType::Cartesian2D:
+      _num_moments_per_group = (_max_anisotropy + 1u) * (_max_anisotropy + 2u) / 2u;
+      break;
+
+    case ProblemType::Cartesian3D:
+      _num_moments_per_group = (_max_anisotropy + 1u) * (_max_anisotropy + 1u);
+      break;
+
+    default:
+      _num_moments_per_group = 0u;
+      break;
+  }
+
   if (_group_index >= _num_groups)
     mooseError("The group index exceeds the number of energy groups.");
 
   if (_ordinate_index >= _aq.totalOrder())
     mooseError("The ordinates index exceeds the number of quadrature points.");
 
-  const unsigned int num_coupled = coupledComponents("group_flux_ordinates");
-  if (num_coupled != _aq.totalOrder() * _num_groups)
+  const unsigned int num_ord = coupledComponents("group_flux_ordinates");
+  if (num_ord != _aq.totalOrder() * _num_groups)
     mooseError("Mismatch between the angular flux ordinates and quadrature set.");
 
-  // Fetch the flux ordinates and their derivatives.
-  _group_flux_ordinates.reserve(num_coupled);
-  for (unsigned int i = 0; i < num_coupled; ++i)
+  // Fetch the flux ordinate derivatives.
+  for (unsigned int i = 0; i < num_ord; ++i)
   {
     unsigned int g = i / _aq.totalOrder();
     unsigned int n = i - g * _aq.totalOrder();
     _jvar_map.emplace(coupled("group_flux_ordinates", i), std::make_pair(g, n));
-    _group_flux_ordinates.emplace_back(&coupledValue("group_flux_ordinates", i));
   }
+
+  const unsigned int num_mom = coupledComponents("group_flux_moments");
+  if (num_mom != _num_moments_per_group * _num_groups)
+    mooseError("Mismatch between the number of angular flux moments and the provided anisotropy / "
+               "number of groups.");
+
+  // Fetch the flux moments.
+  _group_flux_moments.reserve(num_mom);
+  for (unsigned int i = 0; i < num_mom; ++i)
+    _group_flux_moments.emplace_back(&coupledValue("group_flux_moments", i));
 
   if (_max_anisotropy > 3)
     mooseError("Maximum degree of anisotropy supported is at most order 3 at present!");
-}
-
-Real
-SAAFScattering::computeFluxMoment(unsigned int g_prime, unsigned int degree, int order)
-{
-  Real moment = 0.0;
-  for (unsigned int n = 0; n < _aq.totalOrder(); ++n)
-  {
-    const auto & dir = _aq.direction(n);
-    moment += RealSphericalHarmonics::evaluate(degree, order, dir(0), dir(1), dir(2)) *
-              (*_group_flux_ordinates[g_prime * _aq.totalOrder() + n])[_qp] * _aq.weight(n);
-  }
-
-  return moment;
 }
 
 // Compute the full scattering term for both in-group and group-to-group
@@ -98,9 +112,10 @@ SAAFScattering::computeQpResidual()
   const auto & dir = _aq.direction(_ordinate_index);
 
   Real res = 0.0;
-  Real moment_l = 0.0;
   for (unsigned int g_prime = 0; g_prime < _num_groups; ++g_prime)
   {
+    Real moment_l = 0.0;
+    unsigned int sh_offset = 0u;
     unsigned int scattering_index =
         g_prime * _num_groups * (_anisotropy[_qp] + 1u) + _group_index * (_anisotropy[_qp] + 1u);
 
@@ -111,19 +126,29 @@ SAAFScattering::computeQpResidual()
       {
         // Legendre moments in 1D, looping over m is unecessary.
         case ProblemType::Cartesian1D:
-          moment_l += computeFluxMoment(g_prime, l, 0) * RealSphericalHarmonics::evaluate(l, 0, dir(0), dir(1), dir(2));
+          moment_l += (*_group_flux_moments[g_prime * _num_moments_per_group + sh_offset])[_qp] *
+                      RealSphericalHarmonics::evaluate(l, 0, dir(0), dir(1), dir(2));
+          sh_offset++;
           break;
 
         // Need moments with m >= 0 for 2D.
         case ProblemType::Cartesian2D:
           for (int m = 0; m <= static_cast<int>(l); ++m)
-            moment_l += computeFluxMoment(g_prime, l, m) * RealSphericalHarmonics::evaluate(l, m, dir(0), dir(1), dir(2));
+          {
+            moment_l += (*_group_flux_moments[g_prime * _num_moments_per_group + sh_offset])[_qp] *
+                        RealSphericalHarmonics::evaluate(l, m, dir(0), dir(1), dir(2));
+            sh_offset++;
+          }
           break;
 
         // Need all moments in 3D.
         case ProblemType::Cartesian3D:
           for (int m = -1 * static_cast<int>(l); m <= static_cast<int>(l); ++m)
-            moment_l += computeFluxMoment(g_prime, l, m) * RealSphericalHarmonics::evaluate(l, m, dir(0), dir(1), dir(2));
+          {
+            moment_l += (*_group_flux_moments[g_prime * _num_moments_per_group + sh_offset])[_qp] *
+                        RealSphericalHarmonics::evaluate(l, m, dir(0), dir(1), dir(2));
+            sh_offset++;
+          }
           break;
 
         default: // Defaults to doing nothing for now.
@@ -133,8 +158,6 @@ SAAFScattering::computeQpResidual()
       res += (2.0 * static_cast<Real>(l) + 1.0) / (4.0 * libMesh::pi) *
              MetaPhysicL::raw_value(_sigma_s_g_prime_g_l[_qp][scattering_index + l]) * moment_l *
              _symmetry_factor;
-
-      moment_l = 0.0;
     }
   }
 

--- a/src/utils/LSAngularQuadrature.C
+++ b/src/utils/LSAngularQuadrature.C
@@ -24,32 +24,34 @@ LSAngularQuadrature::LSAngularQuadrature(unsigned int q_order, MajorAxis axis, P
     for (unsigned int j = i; j < ((q_order / 2 - i) + 1) / 2; ++j)
     {
       unsigned int k = q_order / 2 - 1 - i - j;
+      // Renormalize weights so they sum to 2\pi (2D) or 4\pi (3D).
+      const auto w = weights[w_idx] * libMesh::pi / 2.0;
       // For each unique combination of x,y,z component magnitudes, permute through all possible
       // permutations (including for positive and negative components).
-      addAllOctantPermutations(mus[i], mus[j], mus[k], weights[w_idx]);
+      addAllOctantPermutations(mus[i], mus[j], mus[k], w);
       if (i == j && i == k)
       {
         // No extra permutations. Do nothing
       }
       else if (i == j)
       {
-        addAllOctantPermutations(mus[k], mus[i], mus[i], weights[w_idx]);
-        addAllOctantPermutations(mus[i], mus[k], mus[i], weights[w_idx]);
+        addAllOctantPermutations(mus[k], mus[i], mus[i], w);
+        addAllOctantPermutations(mus[i], mus[k], mus[i], w);
       }
       else if (j == k)
       {
-        addAllOctantPermutations(mus[j], mus[i], mus[j], weights[w_idx]);
-        addAllOctantPermutations(mus[j], mus[j], mus[i], weights[w_idx]);
+        addAllOctantPermutations(mus[j], mus[i], mus[j], w);
+        addAllOctantPermutations(mus[j], mus[j], mus[i], w);
       }
       else
       {
-        addAllOctantPermutations(mus[k], mus[i], mus[j], weights[w_idx]);
-        addAllOctantPermutations(mus[j], mus[k], mus[i], weights[w_idx]);
-        addAllOctantPermutations(mus[k], mus[j], mus[i], weights[w_idx]);
-        addAllOctantPermutations(mus[i], mus[k], mus[j], weights[w_idx]);
-        addAllOctantPermutations(mus[j], mus[i], mus[k], weights[w_idx]);
+        addAllOctantPermutations(mus[k], mus[i], mus[j], w);
+        addAllOctantPermutations(mus[j], mus[k], mus[i], w);
+        addAllOctantPermutations(mus[k], mus[j], mus[i], w);
+        addAllOctantPermutations(mus[i], mus[k], mus[j], w);
+        addAllOctantPermutations(mus[j], mus[i], mus[k], w);
       }
-      w_idx += 1;
+      w_idx++;
     }
   }
 
@@ -180,6 +182,7 @@ const std::map<unsigned int, std::vector<Real>> LSAngularQuadrature::_ls_mus
   }
 };
 
+// Note: these weights sum to unity over a single octant.
 const std::map<unsigned int, std::vector<Real>> LSAngularQuadrature::_ls_weights
 {
   { 2u,

--- a/tests/transport_system/saaf_cgfem/test_1D_reflected_boundary.i
+++ b/tests/transport_system/saaf_cgfem/test_1D_reflected_boundary.i
@@ -20,6 +20,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tests/transport_system/saaf_cgfem/test_1D_scattering_steady.i
+++ b/tests/transport_system/saaf_cgfem/test_1D_scattering_steady.i
@@ -21,6 +21,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tests/transport_system/saaf_cgfem/test_1D_steady.i
+++ b/tests/transport_system/saaf_cgfem/test_1D_steady.i
@@ -17,6 +17,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tests/transport_system/saaf_cgfem/test_1D_steady_void.i
+++ b/tests/transport_system/saaf_cgfem/test_1D_steady_void.i
@@ -17,6 +17,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tests/transport_system/saaf_cgfem/test_1D_transient.i
+++ b/tests/transport_system/saaf_cgfem/test_1D_transient.i
@@ -21,6 +21,7 @@
     family = LAGRANGE
     constant_ic = 0.0
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tests/transport_system/saaf_cgfem/test_2D_steady.i
+++ b/tests/transport_system/saaf_cgfem/test_2D_steady.i
@@ -19,6 +19,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 1
     n_polar = 1
 

--- a/tutorials/1D_reed_sn/1D_reed.i
+++ b/tutorials/1D_reed_sn/1D_reed.i
@@ -19,6 +19,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_polar = 10
 
     vacuum_boundaries = 'right'

--- a/tutorials/2D_fixed_source/2D_point_source.i
+++ b/tutorials/2D_fixed_source/2D_point_source.i
@@ -22,6 +22,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 2
     n_polar = 2
 

--- a/tutorials/2D_fixed_source/2D_point_source_2_grp.i
+++ b/tutorials/2D_fixed_source/2D_point_source_2_grp.i
@@ -22,6 +22,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 2
     n_polar = 2
 

--- a/tutorials/2D_fixed_source/2D_surface_source_2_grp.i
+++ b/tutorials/2D_fixed_source/2D_surface_source_2_grp.i
@@ -22,6 +22,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 2
     n_polar = 2
 

--- a/tutorials/3D_kobayashi/kobayashi_1.i
+++ b/tutorials/3D_kobayashi/kobayashi_1.i
@@ -34,6 +34,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/tutorials/3D_kobayashi/kobayashi_2.i
+++ b/tutorials/3D_kobayashi/kobayashi_2.i
@@ -28,6 +28,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 

--- a/tutorials/3D_kobayashi/kobayashi_3.i
+++ b/tutorials/3D_kobayashi/kobayashi_3.i
@@ -42,6 +42,7 @@
     order = FIRST
     family = LAGRANGE
 
+    aq_type = 'gauss_chebyshev'
     n_azimuthal = 5
     n_polar = 5
 


### PR DESCRIPTION
This PR improves performance in scattering & fission residual evaluations by using flux moments computed by auxkernels (which already exist in the transport simulation). Angular flux ordinates are still coupled in as primal variables to trigger off-diagonal Jacobian computations.

This PR also fixes a bug in the level-symmetric quadrature set where weights were not normalized to 4*\pi.